### PR TITLE
Prototype 1: Proposal for addressing weakness in entropy pooling.

### DIFF
--- a/src/Fortuna/Fortuna.csproj
+++ b/src/Fortuna/Fortuna.csproj
@@ -6,7 +6,6 @@
     <TargetFramework>netstandard1.3</TargetFramework>
     <AssemblyName>Fortuna</AssemblyName>
     <PackageId>Fortuna</PackageId>
-    <PackageTargetFallback>$(PackageTargetFallback);dnxcore50</PackageTargetFallback>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>

--- a/test/Fortuna.Tests/Fortuna.Tests.csproj
+++ b/test/Fortuna.Tests/Fortuna.Tests.csproj
@@ -4,7 +4,6 @@
     <AssemblyName>Fortuna.Tests</AssemblyName>
     <PackageId>Fortuna.Tests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-    <PackageTargetFallback>$(PackageTargetFallback);netcore50</PackageTargetFallback>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>


### PR DESCRIPTION
There is an issue in how entropy is being preserved in a source's pool.
The initial implementation attempted to perform incremental hashing as
a means to generate a progressive hash of incoming entropy.  This does
not work as intended, as the .NET API does not expose the capability to
calculate hashes of incremental blocks of data.

This solution attempts to obviate the need for storing large strings of
entropic data for rehashing, and instead attempts to seed each hashing
invocation with the results of the previous hashing computation.